### PR TITLE
[FEAT] 카카오 소셜 로그인 API 구현

### DIFF
--- a/src/main/java/com/devloop/auth/controller/AuthController.java
+++ b/src/main/java/com/devloop/auth/controller/AuthController.java
@@ -6,8 +6,13 @@ import com.devloop.auth.request.SignoutRequest;
 import com.devloop.auth.request.SignupRequest;
 import com.devloop.auth.response.SignupResponse;
 import com.devloop.auth.service.AuthService;
+import com.devloop.auth.service.KakaoService;
 import com.devloop.common.AuthUser;
 import com.devloop.common.apipayload.ApiResponse;
+import com.devloop.common.utils.JwtUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,16 +25,17 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class AuthController {
 
-
     private final AuthService authService;
+    private final KakaoService kakaoService;
 
     @PostMapping("/v1/auth/signup")
     public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
         return ApiResponse.ok(authService.createUser(signupRequest));
     }
+
     @PostMapping("/v1/auth/login")
     public ResponseEntity<Object> login(@Valid @RequestBody LoginRequest loginRequest) {
-        return ResponseEntity.status(HttpStatus.OK).header("Authorization",authService.login(loginRequest)).build();
+        return ResponseEntity.status(HttpStatus.OK).header("Authorization", authService.login(loginRequest)).build();
     }
 
     @PutMapping("/v1/auth/signout")
@@ -38,4 +44,14 @@ public class AuthController {
         authService.deleteUser(id, signoutRequest);
         return ResponseEntity.noContent().build();
     }
+
+
+    @GetMapping("/v1/auth/kakao/login")
+    public ResponseEntity<Object> kakaoLogin(@RequestParam String code) throws JsonProcessingException {
+        String token = kakaoService.kakaoLogin(code);
+        return ResponseEntity.status(HttpStatus.OK)
+                .header("Authorization", token)
+                .build();
+    }
 }
+

--- a/src/main/java/com/devloop/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/devloop/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,18 @@
+package com.devloop.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfo {
+    private Long id;
+    private String nickname;
+    private String email;
+
+    public KakaoUserInfo(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/devloop/auth/request/KakaoLoginRequest.java
+++ b/src/main/java/com/devloop/auth/request/KakaoLoginRequest.java
@@ -1,9 +1,0 @@
-package com.devloop.auth.request;
-
-import lombok.Getter;
-
-@Getter
-public class KakaoLoginRequest {
-
-    private String code;
-}

--- a/src/main/java/com/devloop/auth/service/AuthService.java
+++ b/src/main/java/com/devloop/auth/service/AuthService.java
@@ -61,13 +61,13 @@ public class AuthService {
     public String login(LoginRequest loginRequest) {
 
         User user = userRepository.findByEmail(loginRequest.getEmail())
-                .orElseThrow(() ->new ApiException(ErrorStatus._NOT_FOUND_USER));
+                .orElseThrow(() -> new ApiException(ErrorStatus._NOT_FOUND_USER));
 
-        if(!passwordEncoders.matches(loginRequest.getPassword(), user.getPassword())) {
+        if (!passwordEncoders.matches(loginRequest.getPassword(), user.getPassword())) {
             throw new ApiException(ErrorStatus._PERMISSION_DENIED);
         }
 
-        if(user.getStatus() == UserStatus.WITHDRAWAL){
+        if (user.getStatus() == UserStatus.WITHDRAWAL) {
             throw new ApiException(ErrorStatus._NOT_FOUND_USER);
         }
 
@@ -82,9 +82,9 @@ public class AuthService {
     public void deleteUser(Long id, SignoutRequest signoutRequest) {
 
         User user = userRepository.findById(id)
-                .orElseThrow(() ->new ApiException(ErrorStatus._NOT_FOUND_USER));
+                .orElseThrow(() -> new ApiException(ErrorStatus._NOT_FOUND_USER));
 
-        if(passwordEncoders.matches(signoutRequest.getPassword(), user.getPassword())){
+        if (passwordEncoders.matches(signoutRequest.getPassword(), user.getPassword())) {
             user.update();
             userRepository.save(user);
         } else throw new ApiException(ErrorStatus._PERMISSION_DENIED);

--- a/src/main/java/com/devloop/auth/service/KakaoService.java
+++ b/src/main/java/com/devloop/auth/service/KakaoService.java
@@ -1,0 +1,148 @@
+package com.devloop.auth.service;
+
+import com.devloop.auth.dto.KakaoUserInfo;
+import com.devloop.common.utils.JwtUtil;
+import com.devloop.user.entity.User;
+import com.devloop.user.enums.UserRole;
+import com.devloop.user.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Slf4j(topic = "KAKAO Login")
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate;
+    private final JwtUtil jwtUtil;
+
+    public String kakaoLogin(String code) throws JsonProcessingException {
+
+        String accessToken = getToken(code);
+
+        KakaoUserInfo kakaoUserInfo = getKakaoUserInfo(accessToken);
+
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        return jwtUtil.createToken(
+                kakaoUser.getId(),
+                kakaoUser.getEmail(),
+                kakaoUser.getUserRole()
+        );
+    }
+
+    private String getToken(String code) throws JsonProcessingException {
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "3d49a145e53a056301badcfd23ac5373");
+        body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    private KakaoUserInfo getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
+        return new KakaoUserInfo(id, nickname, email);
+    }
+
+    private User registerKakaoUserIfNeeded(KakaoUserInfo kakaoUserInfo) {
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoUserInfo.getId();
+        User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null);
+
+        if (kakaoUser == null) {
+            // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
+            String kakaoEmail = kakaoUserInfo.getEmail();
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
+            if (sameEmailUser != null) {
+                kakaoUser = sameEmailUser;
+                // 기존 회원정보에 카카오 Id 추가
+                kakaoUser = kakaoUser.kakaoIdUpdate(kakaoId);
+            } else {
+                // 신규 회원가입
+                // password: random UUID
+                String password = UUID.randomUUID().toString();
+                String encodedPassword = passwordEncoder.encode(password);
+
+                // email: kakao email
+                String email = kakaoUserInfo.getEmail();
+
+                kakaoUser = new User(kakaoUserInfo.getNickname(), encodedPassword, email, UserRole.ROLE_USER, kakaoId);
+            }
+
+            userRepository.save(kakaoUser);
+        }
+        return kakaoUser;
+    }
+}

--- a/src/main/java/com/devloop/common/utils/JwtUtil.java
+++ b/src/main/java/com/devloop/common/utils/JwtUtil.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 @Component
 public class JwtUtil {
 
+    // 상수 추가
+    public static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
 

--- a/src/main/java/com/devloop/config/RestTemplateConfig.java
+++ b/src/main/java/com/devloop/config/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.devloop.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig  {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}

--- a/src/main/java/com/devloop/config/WebSecurityConfig.java
+++ b/src/main/java/com/devloop/config/WebSecurityConfig.java
@@ -36,7 +36,12 @@ public class WebSecurityConfig {
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .logout(logout -> logout.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers(
+                                "/api/v1/auth/signup",
+                                "/api/v1/auth/login",
+                                "/api/v1/auth/kakao/login",
+                                "/api/v1/auth/kakao/callback")
+                        .permitAll()
                         .anyRequest().authenticated()
                 )
                 .build();

--- a/src/main/java/com/devloop/user/entity/User.java
+++ b/src/main/java/com/devloop/user/entity/User.java
@@ -6,7 +6,6 @@ import com.devloop.user.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 @Entity
 @NoArgsConstructor
@@ -30,7 +29,8 @@ public class User extends Timestamped {
     @Enumerated(EnumType.STRING)
     private UserStatus status = UserStatus.ACTIVE;
 
-    private Long kakaoid;
+
+    private Long kakaoId;
 
     public User(String username, String email, String password, UserRole userRole) {
         this.username = username;
@@ -41,5 +41,18 @@ public class User extends Timestamped {
 
     public void update() {
         this.status = UserStatus.WITHDRAWAL;
+    }
+
+    public User(String username, String password, String email, UserRole userRole, Long kakaoId) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.userRole = userRole;
+        this.kakaoId =kakaoId;
+    }
+
+    public User kakaoIdUpdate(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
     }
 }

--- a/src/main/java/com/devloop/user/enums/UserStatus.java
+++ b/src/main/java/com/devloop/user/enums/UserStatus.java
@@ -1,6 +1,14 @@
 package com.devloop.user.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum UserStatus {
 
-ACTIVE, WITHDRAWAL
+    ACTIVE("계정 활성 상태"),
+    WITHDRAWAL("계정 탈퇴 상태");
+
+    private final String UserStatus;
 }

--- a/src/main/java/com/devloop/user/repository/UserRepository.java
+++ b/src/main/java/com/devloop/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(@NotBlank(message = "이메일은 필수 입력사항입니다.") @Email(message = "이메일 형식을 맞춰주세요.") String email);
+    Optional<User> findByKakaoId(Long kakaoId);
 }


### PR DESCRIPTION
- AuthController 
- GetMapping으로 kakaoLogin 기능 추가
- ㄴ 왜 Get? OAuth 2.0 프로토콜의 인가 승인 방식에서 리다이렉트 URL은 GET 방식을 사용하도록 규정
-------------------------------------------------------------------------------

-  kakaoService
- kakaoLogin 비즈니스 로직 추가

-------------------------------------------------------------------------------

- kakaoUserInfo
- kakaoUSerInfo dto를 통해서 소셜로그인에서 정보를 가져옴

-------------------------------------------------------------------------------

- User Entity
- 카카오 로그인 관련 로직 추가

-------------------------------------------------------------------------------

- GlobalException 내용 추가

-------------------------------------------------------------------------------